### PR TITLE
Earnapp - Remove Unused devices

### DIFF
--- a/scripts/earnappTotals.user.js
+++ b/scripts/earnappTotals.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         EarnApp Daily Totals
 // @namespace    https://github.com/Gibado
-// @version      2022.4.26.0
+// @version      2022.5.17.0
 // @description  Adds daily earned totals under the data graph
 // @author       Tyler Studanski
 // @match        https://earnapp.com/*
@@ -14,196 +14,218 @@
 // ==/UserScript==
 
 document.myEarnApp = function() {
-	var self = this;
-	self.usageData = undefined;
-	self.deviceMap = {};
+    var self = this;
+    self.usageData = undefined;
+    self.deviceMap = {};
 
-	// Main function to run
-	self.run = function() {
-		self.reset();
-		self.grabUsage();
-	};
+    // Main function to run
+    self.run = function() {
+        self.reset();
+        self.grabUsage();
+    }
 
-	// Resets the data properties
-	self.reset = function() {
-		self.usageData = undefined;
-		self.deviceMap = {};
-	};
+    // Resets the data properties
+    self.reset = function() {
+        self.usageData = undefined;
+        self.deviceMap = {};
+    }
 
-	// Fetches data uses per machine and adds them to the usageData property
-	self.grabUsage = function() {
-		$.ajax({
-			'url' : 'https://earnapp.com/dashboard/api/usage?appid=earnapp_dashboard&version=1.292.111&step=daily',
-			'type' : 'GET',
-			'success' : function(data) {
-				self.usageData = data;
-				self.processUsage(self.usageData);
-				self.updateCounts(self.deviceMap);
-				self.addToPage(self.deviceMap);
-			},
-			'error' : function(request,error)
-			{
-				console.error("Request: "+JSON.stringify(request));
-			}
-		});
-	};
+    // Fetches data uses per machine and adds them to the usageData property
+    self.grabUsage = function() {
+        $.ajax({
+            'url': 'https://earnapp.com/dashboard/api/usage?appid=earnapp_dashboard&version=1.292.111&step=daily',
+            'type': 'GET',
+            'success': function(data) {
+                self.usageData = data;
+                self.processUsage(self.usageData);
+                self.updateCounts(self.deviceMap);
+                self.addToPage(self.deviceMap);
+            },
+            'error': function(request, error) {
+                console.error("Request: " + JSON.stringify(request));
+            }
+        });
+    }
 
-	// Adds data to deviceMap property and finds average and total byte usage for each date
-	// The daily averages and totals are treated as devices to calculate averages and totals across the week
-	self.processUsage = function(usageData) {
-		if (usageData === undefined) {
-			return;
-		}
-		var total = undefined;
-		for (const machine of usageData) {
-			self.deviceMap[machine.name] = {
-				data: JSON.parse(JSON.stringify(machine.data))
-			};
+    // Adds data to deviceMap property and finds average and total byte usage for each date
+    // The daily averages and totals are treated as devices to calculate averages and totals across the week
+    self.processUsage = function(usageData) {
+        if (usageData === undefined) {
+            return;
+        }
+        // filter out unused machines
+        var deviceNames = self.grabCurrentDevices();
+        var currentMachines = [];
+        deviceNames.forEach(function(device) {
+            usageData.forEach(function(machine) {
+                if (machine.name === device) {
+                    currentMachines.push(machine);
+                    return;
+                }
+            });
+        });
 
-			// Calculate daily totals
-			if (total === undefined) {
-				total = JSON.parse(JSON.stringify(self.deviceMap[machine.name]));
-			} else {
-				for (const date in machine.data) {
-					total.data[date] += machine.data[date];
-				}
-			}
-		}
+        var total = undefined;
+        for (const machine of currentMachines) {
+            self.deviceMap[machine.name] = {
+                data: JSON.parse(JSON.stringify(machine.data))
+            };
 
-		// Calculate daily averages
-		self.deviceMap.Average = JSON.parse(JSON.stringify(total));
-		for (const date in self.deviceMap.Average.data) {
-			self.deviceMap.Average.data[date] /= usageData.length;
-		}
-		self.deviceMap.Total = total;
-    };
+            // Calculate daily totals
+            if (total === undefined) {
+                total = JSON.parse(JSON.stringify(self.deviceMap[machine.name]));
+            } else {
+                for (const date in machine.data) {
+                    total.data[date] += machine.data[date];
+                }
+            }
+        }
 
-	// Calculates KB, MB, and GB use for each machine and their individual earnings
-	self.updateCounts = function(deviceMap) {
-		for (const device in deviceMap) {
-			// Convert all bytes to GB
-			deviceMap[device].totalGBytes = 0;
-			for (const date in deviceMap[device].data) {
-				deviceMap[device].data[date] /= Math.pow(1024,3); // kilo-, mega-, and giga-byte
-				deviceMap[device].totalGBytes += deviceMap[device].data[date];
-			}
-			// Add device average
-			deviceMap[device].avgGBytes = deviceMap[device].totalGBytes / 7;
+        // Calculate daily averages
+        self.deviceMap.Average = JSON.parse(JSON.stringify(total));
+        for (const date in self.deviceMap.Average.data) {
+            self.deviceMap.Average.data[date] /= currentMachines.length;
+        }
+        self.deviceMap.Total = total;
+    }
 
-			// Add Earnings
-			deviceMap[device].totalEarnings = self.formatter.format(deviceMap[device].totalGBytes / 2);
-			deviceMap[device].avgEarnings = self.formatter.format(deviceMap[device].avgGBytes / 2);
-		}
-	};
+    // Returns a list of device names that appear in the graph
+    self.grabCurrentDevices = function() {
+        var devices = [];
+        $('div.eadt_list_cell_device').toArray().forEach(function(device) {
+            devices.push(device.textContent);
+        });
+        // Remove the 1st entry since it's a label
+        devices.shift();
+        return devices;
+    }
 
-	// Adds/updates display with current data
-	self.addToPage = function(deviceMap) {
+    // Calculates KB, MB, and GB use for each machine and their individual earnings
+    self.updateCounts = function(deviceMap) {
+        for (const device in deviceMap) {
+            // Convert all bytes to GB
+            deviceMap[device].totalGBytes = 0;
+            for (const date in deviceMap[device].data) {
+                deviceMap[device].data[date] /= Math.pow(1024, 3); // kilo-, mega-, and giga-byte
+                deviceMap[device].totalGBytes += deviceMap[device].data[date];
+            }
+            // Add device average
+            deviceMap[device].avgGBytes = deviceMap[device].totalGBytes / 7;
 
-		var display = self.getDisplay();
+            // Add Earnings
+            deviceMap[device].totalEarnings = self.formatter.format(deviceMap[device].totalGBytes / 2);
+            deviceMap[device].avgEarnings = self.formatter.format(deviceMap[device].avgGBytes / 2);
+        }
+    }
 
-		for(;display.childElementCount > 0;) {
-			display.childNodes[0].remove();
-		}
+    // Adds/updates display with current data
+    self.addToPage = function(deviceMap) {
 
-		display.appendChild(self.buildTable(deviceMap));
-    };
+        var display = self.getDisplay();
 
-	// Returns existing div to display information or builds a new one
-	self.getDisplay = function() {
-		var display = document.getElementById('earningDisplay');
-		if (display !== null) {
-			return display;
-		}
+        for (; display.childElementCount > 0;) {
+            display.childNodes[0].remove();
+        }
 
-		// Build display
-		var landing = document.getElementsByClassName('ea_usage_chart')[0];
-		display = document.createElement('div');
-		display.id = 'earningDisplay';
+        display.appendChild(self.buildTable(deviceMap));
+    }
 
-		landing.appendChild(display);
-		return display;
-	};
+    // Returns existing div to display information or builds a new one
+    self.getDisplay = function() {
+        var display = document.getElementById('earningDisplay');
+        if (display !== null) {
+            return display;
+        }
 
-	// Creates table to display statistics to user
-	self.buildTable = function(deviceMap) {
-		var table = document.createElement('table');
-		table.border = 1;
-		// Add headers
-		var headers = document.createElement('tr');
-		table.appendChild(headers);
+        // Build display
+        var landing = document.getElementsByClassName('ea_usage_chart')[0];
+        display = document.createElement('div');
+        display.id = 'earningDisplay';
 
-		var headerData = ['Device'];
-		headerData = headerData.concat(Object.keys(deviceMap.Total.data).reverse());
-		headerData = headerData.concat('Avg GB', 'Total GB', 'Avg $', 'Total $');
+        landing.appendChild(display);
+        return display;
+    }
 
-		self.createRow('th', headers, headerData);
+    // Creates table to display statistics to user
+    self.buildTable = function(deviceMap) {
+        var table = document.createElement('table');
+        table.border = 1;
+        // Add headers
+        var headers = document.createElement('tr');
+        table.appendChild(headers);
 
-		Object.keys(deviceMap).forEach(function(device) {
-			// Add data
-			var deviceRow = document.createElement('tr');
-			table.appendChild(deviceRow);
+        var headerData = ['Device'];
+        headerData = headerData.concat(Object.keys(deviceMap.Total.data).reverse());
+        headerData = headerData.concat('Avg GB', 'Total GB', 'Avg $', 'Total $');
 
-			var dataRow = [device];
-			Object.values(deviceMap[device].data).reverse().forEach(function(total) {
-				dataRow = dataRow.concat(total.toFixed(2));
-			});
-			dataRow = dataRow.concat(deviceMap[device].avgGBytes.toFixed(2), deviceMap[device].totalGBytes.toFixed(2), deviceMap[device].avgEarnings, deviceMap[device].totalEarnings);
+        self.createRow('th', headers, headerData);
 
-			self.createRow('td', deviceRow, dataRow);
-		});
+        Object.keys(deviceMap).forEach(function(device) {
+            // Add data
+            var deviceRow = document.createElement('tr');
+            table.appendChild(deviceRow);
 
-		return table;
-	};
+            var dataRow = [device];
+            Object.values(deviceMap[device].data).reverse().forEach(function(total) {
+                dataRow = dataRow.concat(total.toFixed(2));
+            });
+            dataRow = dataRow.concat(deviceMap[device].avgGBytes.toFixed(2), deviceMap[device].totalGBytes.toFixed(2), deviceMap[device].avgEarnings, deviceMap[device].totalEarnings);
 
-	// Adds the given data to a table row with the given type (th/td)
-	self.createRow = function(elementType, parentElement, dataArray) {
-		Object.values(dataArray).forEach(function(data) {
-			var column = document.createElement(elementType);
-			column.textContent = data;
-			parentElement.appendChild(column);
-		});
-	};
+            self.createRow('td', deviceRow, dataRow);
+        });
 
-	// Debug function
-	self.printResults = function() {
-		console.log(self.usageData);
-		console.log(self.deviceMap);
-	};
+        return table;
+    }
+
+    // Adds the given data to a table row with the given type (th/td)
+    self.createRow = function(elementType, parentElement, dataArray) {
+        Object.values(dataArray).forEach(function(data) {
+            var column = document.createElement(elementType);
+            column.textContent = data;
+            parentElement.appendChild(column);
+        });
+    }
+
+    // Debug function
+    self.printResults = function() {
+        console.log(self.usageData);
+        console.log(self.deviceMap);
+    }
 
     // Checks if this is the correct page and waits the intervalTime before checking again
-	// intervalTime: time in milliseconds before each check
-	self.delayedRun = function(intervalTime) {
-		setTimeout(function(){
+    // intervalTime: time in milliseconds before each check
+    self.delayedRun = function(intervalTime) {
+        setTimeout(function() {
             if (!self.validateSite()) {
-				self.delayedRun(intervalTime);
-			} else {
-				self.run();
-			}
-		}, intervalTime);
-	};
+                self.delayedRun(intervalTime);
+            } else {
+                self.run();
+            }
+        }, intervalTime);
+    }
 
     // Returns true if the site has the proper information available
     self.validateSite = function() {
         console.log('Checking for valid site...');
         return document.getElementsByClassName('ea_usage_chart').length > 0;
-    };
+    }
 
-	// Copied from https://stackoverflow.com/a/16233919/3416155
-	// Create our number formatter.
-	self.formatter = new Intl.NumberFormat('en-US', {
-	  style: 'currency',
-	  currency: 'USD',
+    // Copied from https://stackoverflow.com/a/16233919/3416155
+    // Create our number formatter.
+    self.formatter = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
 
-	  // These options are needed to round to whole numbers if that's what you want.
-	  //minimumFractionDigits: 0, // (this suffices for whole numbers, but will print 2500.10 as $2,500.1)
-	  //maximumFractionDigits: 0, // (causes 2500.99 to be printed as $2,501)
-	});
+        // These options are needed to round to whole numbers if that's what you want.
+        //minimumFractionDigits: 0, // (this suffices for whole numbers, but will print 2500.10 as $2,500.1)
+        //maximumFractionDigits: 0, // (causes 2500.99 to be printed as $2,501)
+    })
 
-	return self;
-};
+    return self;
+}
 
 // Delay the run to give the site a chance to load
 setTimeout(function() {
-	earnAppModel = document.myEarnApp();
-	earnAppModel.delayedRun(1000);
+    earnAppModel = document.myEarnApp();
+    earnAppModel.delayedRun(1000);
 }, 10);


### PR DESCRIPTION
### Bug:
The statistics table is listing devices that are no longer in use.  This is also skewing the average values.

### Cause:
When fetching the device usage data, all historical devices are included.

### How:
Now the devices in the usage data are filtered out if they don't exist in the list of current devices grabbed from the page.  The `grabCurrentDevices` is the new function that's used to filter out these devices in the `processUsage` function.

### Extra:
- Changed tabs to spaces